### PR TITLE
fix: make Go build scripts location-independent

### DIFF
--- a/.github/workflows/tooling.yml
+++ b/.github/workflows/tooling.yml
@@ -145,7 +145,10 @@ jobs:
   cpp-mingw:
     name: C++ cross-build (Linux to Windows)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Hosted Ubuntu package mirrors can occasionally take longer than the
+    # compiler build itself. Keep a bounded timeout without making a transient
+    # apt mirror delay cancel an otherwise healthy cross-build.
+    timeout-minutes: 30
 
     steps:
       - name: Check out source

--- a/Tool/Go/build.ps1
+++ b/Tool/Go/build.ps1
@@ -7,6 +7,7 @@ $ErrorActionPreference = 'Stop'
 $previousCgo = $env:CGO_ENABLED
 $previousOs = $env:GOOS
 $previousArch = $env:GOARCH
+$scriptRoot = [IO.Path]::GetFullPath($PSScriptRoot)
 
 function Invoke-GoCommand {
     param([Parameter(Mandatory)][string[]] $Arguments)
@@ -17,6 +18,7 @@ function Invoke-GoCommand {
     }
 }
 
+Push-Location -LiteralPath $scriptRoot
 try {
     if (-not $SkipTests) {
         Invoke-GoCommand @('test', '-count=10', './...')
@@ -59,15 +61,15 @@ try {
         )
     }
 
-    Get-ChildItem -LiteralPath 'bin' -Recurse -File |
-        Sort-Object FullName |
-        ForEach-Object {
-            $hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $_.FullName).Hash
-            Write-Output "$($_.FullName)|$($_.Length)|$hash"
-        }
+    foreach ($target in $targets) {
+        $artifact = Get-Item -LiteralPath $target.Output
+        $hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $artifact.FullName).Hash
+        Write-Output "$($artifact.FullName)|$($artifact.Length)|$hash"
+    }
 }
 finally {
     $env:CGO_ENABLED = $previousCgo
     $env:GOOS = $previousOs
     $env:GOARCH = $previousArch
+    Pop-Location
 }

--- a/Tool/Go/build.sh
+++ b/Tool/Go/build.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env sh
 set -eu
 
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+cd "$script_dir"
+
 if [ "${1:-}" != "--skip-tests" ]; then
 	go test -count=10 ./...
 	go vet ./...


### PR DESCRIPTION
## Summary

- make the Go PowerShell and POSIX build scripts change to their own module directory
- allow documented invocation from the repository root or any caller directory
- report hashes for exactly the three produced target artifacts instead of unrelated stale binaries

## Validation

- `pwsh -File Tool/Go/build.ps1` passed from the repository root, including ten-pass tests, vet, and all three CGO-free cross-builds
- `bash Tool/Go/build.sh --skip-tests` passed from the repository root
- PowerShell parse, `bash -n`, and `git diff --check` passed