### PR TITLE
Fix cold .local resolution in native transfer clients

### DIFF
--- a/Tool/C#/README.md
+++ b/Tool/C#/README.md
@@ -22,6 +22,10 @@ Uploads:
 - cache a `.local` address and perform at most one safe re-resolution after a
   connection failure.
 
+The default DNS/connect deadline is 20 seconds so a cold Windows mDNS lookup
+through a VPN or newly initialized adapter is not mistaken for an offline
+device. `--connect-timeout` remains available for explicit tuning.
+
 Downloads:
 
 - derive `/firmware/download` from the update endpoint unless

--- a/Tool/C#/Uploader/SelfTests.cs
+++ b/Tool/C#/Uploader/SelfTests.cs
@@ -240,6 +240,10 @@ internal static class SelfTests
             "http://should-not-be-used.invalid/update");
         True(parsed.Error is null && parsed.Options is not null, "valid CLI parsed");
         Equal("127.0.0.1", parsed.Options!.UpdateApi.Host, "CLI URL overrides UPDATE_API");
+        Equal(
+            TimeSpan.FromSeconds(20),
+            parsed.Options.ConnectTimeout,
+            "default allows a cold Windows mDNS lookup");
         Equal(TimeSpan.Zero, parsed.Options.InitialPollDelay, "zero initial delay accepted");
 
         var invalid = UploaderOptions.Parse(

--- a/Tool/C#/Uploader/UploaderOptions.cs
+++ b/Tool/C#/Uploader/UploaderOptions.cs
@@ -27,6 +27,8 @@ internal sealed record RequestHeader(string Name, string Value);
 
 internal sealed record UploaderOptions
 {
+    private const double DefaultConnectTimeoutSeconds = 20;
+
     public TransferMode Mode { get; init; } = TransferMode.Upload;
     public string FirmwarePath { get; init; } = string.Empty;
     public string ManifestPath { get; init; } = string.Empty;
@@ -34,7 +36,8 @@ internal sealed record UploaderOptions
     public required Uri UpdateApi { get; init; }
     public Uri? DownloadApi { get; init; }
     public IReadOnlyList<RequestHeader> RequestHeaders { get; init; } = [];
-    public TimeSpan ConnectTimeout { get; init; } = TimeSpan.FromSeconds(5);
+    public TimeSpan ConnectTimeout { get; init; } =
+        TimeSpan.FromSeconds(DefaultConnectTimeoutSeconds);
     public TimeSpan UploadTimeout { get; init; } = TimeSpan.FromMinutes(2);
     public TimeSpan DownloadTimeout { get; init; } = TimeSpan.FromMinutes(2);
     public TimeSpan RebootTimeout { get; init; } = TimeSpan.FromSeconds(45);
@@ -92,7 +95,7 @@ internal sealed record UploaderOptions
         string? bearer = string.IsNullOrWhiteSpace(environmentBearer) ? null : environmentBearer;
         string? backupPath = null;
         var headers = new List<RequestHeader>();
-        var connectTimeout = TimeSpan.FromSeconds(5);
+        var connectTimeout = TimeSpan.FromSeconds(DefaultConnectTimeoutSeconds);
         var uploadTimeout = TimeSpan.FromMinutes(2);
         var downloadTimeout = TimeSpan.FromMinutes(2);
         var rebootTimeout = TimeSpan.FromSeconds(45);
@@ -396,7 +399,7 @@ internal sealed record UploaderOptions
         writer.WriteLine("      --resume               Resume one existing .part with a strict Range request");
         writer.WriteLine("      --bearer TOKEN         Add Authorization: Bearer TOKEN (never logged)");
         writer.WriteLine("      --header NAME:VALUE    Add a private request header; repeat as needed");
-        writer.WriteLine("      --connect-timeout SEC  DNS/connect timeout (default: 5)");
+        writer.WriteLine("      --connect-timeout SEC  DNS/connect timeout (default: 20)");
         writer.WriteLine("      --download-timeout SEC Whole download timeout (default: 120)");
         writer.WriteLine("      --no-verify            Disable remote-hash verification (not recommended)");
         writer.WriteLine();

--- a/Tool/C++/README.md
+++ b/Tool/C++/README.md
@@ -79,6 +79,10 @@ A cached address may be resolved one additional time after a safe, pre-body
 network failure. A request is never automatically replayed after firmware bytes
 may have been committed. Redirects are rejected.
 
+The default DNS/connect deadline is 20 seconds to accommodate cold Windows
+mDNS resolution through VPN and newly initialized adapters. Override it with
+`--connect-timeout-ms` when needed.
+
 ## Download and backup
 
 ```powershell

--- a/Tool/C++/upload.cpp
+++ b/Tool/C++/upload.cpp
@@ -403,7 +403,7 @@ struct Options {
     fs::path download;
     std::wstring endpoint;
     std::wstring authorization;
-    int connect_timeout_ms = 5000;
+    int connect_timeout_ms = 20000;
     int request_timeout_ms = 10000;
     int reboot_timeout_ms = 30000;
     int poll_interval_ms = 750;
@@ -813,7 +813,7 @@ void print_usage() {
         << "      --download PATH         Verified atomic download without upload\n"
         << "      --no-resume             Ignore an existing PATH.part download\n"
         << "      --no-verify             Explicitly disable post-reboot verification\n"
-        << "      --connect-timeout-ms N  Connect timeout (default: 5000)\n"
+        << "      --connect-timeout-ms N  Connect timeout (default: 20000)\n"
         << "      --request-timeout-ms N  Request timeout (default: 10000)\n"
         << "      --reboot-timeout-ms N   Post-hash deadline (default: 30000)\n"
         << "      --poll-interval-ms N    Verification interval (default: 750)\n"
@@ -2740,6 +2740,11 @@ void expect_self_test(bool condition, std::string_view message) {
 }
 
 void run_self_test() {
+    const Options defaults;
+    expect_self_test(
+        defaults.connect_timeout_ms == 20000,
+        "default allows a cold Windows mDNS lookup");
+
     const std::string fixture =
         "90EDAD71A57D0437412D2F3F9EAA46BF *folder/firmware.bin\n"
         "6fb510b13cdc013ad7a29b68f326f37c *firmware.bin (compressed)\r\n";

--- a/Tool/Go/README.md
+++ b/Tool/Go/README.md
@@ -93,6 +93,9 @@ compatible. A hostname is resolved once and pinned for the process. A failed
 cached connection permits one fresh resolution. Device-supplied terminal text
 is control-character sanitized.
 
+The initial lookup has a bounded 20-second window so cold Windows mDNS through
+a VPN or newly initialized adapter can complete before the address is pinned.
+
 Stable process exit codes are:
 
 - `0`: requested operation completed and verification passed

--- a/Tool/Go/main.go
+++ b/Tool/Go/main.go
@@ -32,6 +32,7 @@ const (
 	defaultTimeout  = 45 * time.Second
 	defaultReboot   = 75 * time.Second
 	defaultInterval = 2 * time.Second
+	lookupTimeout   = 20 * time.Second
 	maxResponseSize = 1 << 20
 	maxFirmwareSize = 16 << 20
 	exitSuccess     = 0
@@ -523,7 +524,10 @@ func resolveHTTPURL(
 	originalHost := parsed.Hostname()
 	resolvedIP := originalHost
 	if net.ParseIP(originalHost) == nil {
-		lookupCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		// A cold Windows mDNS lookup can legitimately take more than five
+		// seconds, especially through a VPN adapter. Resolve once with a
+		// realistic bound, then keep using the pinned address.
+		lookupCtx, cancel := context.WithTimeout(ctx, lookupTimeout)
 		defer cancel()
 		addresses, lookupErr := net.DefaultResolver.LookupIPAddr(
 			lookupCtx,

--- a/Tool/Go/main_test.go
+++ b/Tool/Go/main_test.go
@@ -25,6 +25,13 @@ func TestParseOptionsHelp(t *testing.T) {
 	}
 }
 
+func TestLookupTimeoutAllowsColdMDNS(t *testing.T) {
+	t.Parallel()
+	if lookupTimeout != 20*time.Second {
+		t.Fatalf("lookup timeout = %s, want 20s", lookupTimeout)
+	}
+}
+
 func TestReadManifest(t *testing.T) {
 	t.Parallel()
 	directory := t.TempDir()

--- a/Tool/README.md
+++ b/Tool/README.md
@@ -42,6 +42,11 @@ The tools pin a resolved `.local` address for a transfer and allow one fresh
 resolution only after a safe connection failure. They do not blindly replay an
 ambiguous upload.
 
+The native clients allow 20 seconds by default for a cold DNS-SD/mDNS lookup.
+This avoids false failures on Windows systems where `.local` resolution crosses
+a VPN or a newly initialized network adapter; the resolved address is still
+looked up only once and then pinned.
+
 ## Validate every implementation
 
 On Windows with Node.js, Go, .NET 8, Python 3, CMake, and a Visual Studio


### PR DESCRIPTION
## Summary
- raise the native Go, .NET, and C++ DNS/connect lookup defaults from 5s to 20s
- preserve one-time address pinning and the existing single safe refresh policy
- document and regression-test the cold Windows mDNS/VPN case

## Validation
- Go tests repeated 10x and `go vet ./...`
- .NET warning-as-error build and 114 self-test assertions
- native C++ x64 build plus 2/2 CTest integration tests
- each updated client resolved `rayanlamp.local` and atomically downloaded the live 433,744-byte firmware with MD5 `0ba19dfb69ec8b75286ff83915ede88c`